### PR TITLE
increase size of value buffer

### DIFF
--- a/sysctl-logger.h
+++ b/sysctl-logger.h
@@ -2,7 +2,7 @@
 #define __SYSCTL_LOGGER_H
 
 #define MAX_NAME_STR_LEN 48
-#define MAX_VALUE_STR_LEN 0x40
+#define MAX_VALUE_STR_LEN 0x80
 #define TASK_COMM_LEN 16
 
 struct sysctl_logger_event {


### PR DESCRIPTION
Avoid truncation of longer sysctl values e.g.
kernel.core_pattern - a custom value might be longer than 64 bytes