### PR TITLE
Add parent pid/comm

### DIFF
--- a/sysctl-logger.bpf.c
+++ b/sysctl-logger.bpf.c
@@ -2,16 +2,24 @@
 // Copyright (c) 2019 Facebook
 
 #include <vmlinux.h>
+#include <linux/version.h>
 
 #include <linux/errno.h>
 #include <bpf/bpf_helpers.h>
 
 #include "sysctl-logger.h"
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0)
+#define HAVE_BPF_RCU_READ_LOCK
+#endif
+
 struct {
 	__uint(type, BPF_MAP_TYPE_RINGBUF);
 	__uint(max_entries, 512 * 1024 /* 256 KB */);
 } rb SEC(".maps");
+
+void bpf_rcu_read_lock(void) __ksym;
+void bpf_rcu_read_unlock(void) __ksym;
 
 SEC("cgroup/sysctl")
 int sysctl_logger(struct bpf_sysctl *ctx)
@@ -38,9 +46,15 @@ int sysctl_logger(struct bpf_sysctl *ctx)
 #endif /* HAVE_CGROUP_CURRENT_FUNC_PROTO */
 
 	struct task_struct *parent;
+#ifdef HAVE_BPF_RCU_READ_LOCK
+        bpf_rcu_read_lock();
+#endif /*  HAVE_BPF_RCU_READ_LOCK */
 	bpf_probe_read_kernel(&parent, sizeof(parent), &current->real_parent);
 	bpf_probe_read_kernel(&event->parent_pid, sizeof(event->parent_pid), &parent->pid);
 	bpf_probe_read_kernel_str(&event->parent_comm, sizeof(event->parent_comm), &parent->comm);
+#ifdef HAVE_BPF_RCU_READ_LOCK
+        bpf_rcu_read_unlock();
+#endif /*  HAVE_BPF_RCU_READ_LOCK */
 
 	__builtin_memset(event->name, 0, sizeof(event->name));
 	ret = bpf_sysctl_get_name(ctx, event->name, sizeof(event->name), 0);

--- a/sysctl-logger.c
+++ b/sysctl-logger.c
@@ -50,8 +50,9 @@ int handle_ringbuf_event(void *ctx, void *data, size_t data_sz)
 	event.new_value[strcspn(event.new_value, "\n")] = 0;
 
 	if (event.truncated || strncmp(event.old_value, event.new_value, sizeof(event.new_value))) {
-		printf("%s[%d] changed %s from %s to %s%s\n", event.comm, event.pid,
-			event.name, event.old_value, event.new_value, warning);
+		printf("%s[%d](%s[%d]) changed %s from %s to %s%s\n",
+                       event.comm, event.pid, event.parent_comm, event.parent_pid,
+                       event.name, event.old_value, event.new_value, warning);
 		fflush(stdout);
 	}
 

--- a/sysctl-logger.h
+++ b/sysctl-logger.h
@@ -7,8 +7,10 @@
 
 struct sysctl_logger_event {
 	int pid;
+	int parent_pid;
 	bool truncated;
 	char comm[TASK_COMM_LEN];
+	char parent_comm[TASK_COMM_LEN];
 	char name[MAX_NAME_STR_LEN];
 	char old_value[MAX_VALUE_STR_LEN];
 	char new_value[MAX_VALUE_STR_LEN];


### PR DESCRIPTION
We would like to have the parent info in the logs.

sysctl\[3319](sapconf\[3192]) changed kernel/shmmni from 4096 to 32768

In situations when sysctl is used to change a parameter, the caller info might be more interesting than the callee info of sysctl.