### PR TITLE
Makefile: visible output directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
-OUTPUT := .output
+OUTPUT := output
 LIBDIR ?= /usr/lib64
 SBINDIR ?= /usr/sbin
 UNITDIR ?= /usr/lib/systemd/system


### PR DESCRIPTION
Placing the compiler output into hidden directories leaves a bad impression.